### PR TITLE
fix: prepare wasabi backend image

### DIFF
--- a/manager/engine/wasabi_engine.py
+++ b/manager/engine/wasabi_engine.py
@@ -38,6 +38,7 @@ class WasabiEngine(EngineBase):
         print("Preparing images")
         self.prepare_image("btc-node")
         self.prepare_client_images()
+        self.prepare_image("wasabi-backend")
 
     def prepare_client_images(self):
         for version in self.versions:


### PR DESCRIPTION
Wasabi emulations didn't work with docker because the wasabi backend wasn't built. This PR is just adding the one missing line so that the wasabi backend is prepared before the emulator tries to start it. 